### PR TITLE
asynchronously download resources

### DIFF
--- a/src/mirror_tarball.jl
+++ b/src/mirror_tarball.jl
@@ -17,7 +17,7 @@ Set environment variable `JULIA_NUM_THREADS` to enable multi-threads.
 - `http_parameters::Dict{Symbol, Any}`: any parameters that need to pass to `HTTP.get` when fetching resources.
 - `packages::AbstractVector{Package}`: manually create and specify a set of packages that needed to be stored. This
    can be used to build only a partial of the complete storage. Check [`read_packages`](@ref read_packages) for how
-   to build packages info. (Experimental)
+   to build packages info.
 - `show_progress::Bool`: `true` to show an additional progress meter. By default it is `true`.
 
 """
@@ -114,15 +114,13 @@ function mirror_tarball(
     p = show_progress ? Progress(num_versions; desc="$name: Pulling packages: ") : nothing
     for pkg in packages
         for (ver, hash_info) in pkg.versions
-            begin
             tree_hash = hash_info["git-tree-sha1"]
             resource = "/package/$(pkg.uuid)/$(tree_hash)"
             tarball = joinpath(static_dir, "package", pkg.uuid, tree_hash)
-                show_progress && @info "downloading package..." package=pkg.name uuid=pkg.uuid hash=tree_hash resource=resource tarball = tarball
-                _download(resource, tarball)
-                isnothing(p) || ProgressMeter.next!(p; showvalues = [(:package, pkg.name), (:version, ver), (:uuid, pkg.uuid), (:hash, tree_hash)])
+            show_progress && @info "downloading package..." package=pkg.name uuid=pkg.uuid hash=tree_hash resource=resource tarball = tarball
+            _download(resource, tarball)
+            isnothing(p) || ProgressMeter.next!(p; showvalues = [(:package, pkg.name), (:version, ver), (:uuid, pkg.uuid), (:hash, tree_hash)])
         end
-    end
     end
 
     # 4. read and download `/artifact/$hash`
@@ -133,7 +131,7 @@ function mirror_tarball(
     p = show_progress ? Progress(length(artifacts); desc="$name: Pulling artifacts: ") : nothing
     batch_size = min(length(artifacts), max(20, ceil(Int, length(artifacts)/(5*Threads.nthreads()))))
     for artifact in artifacts
-            if is_valid(artifact)
+        if is_valid(artifact)
             tree_hash = artifact.hash
             resource = "/artifact/$(tree_hash)"
             tarball = joinpath(static_dir, "artifact", tree_hash)

--- a/src/utils/server_utils.jl
+++ b/src/utils/server_utils.jl
@@ -10,7 +10,7 @@ const resource_re = Regex("""
 """, "x")
 
 """
-    query_latest_hash(registry, server; timeout=15000)
+    query_latest_hash(registry, server; timeout=30_000)
 
 Interrogate a storage server for a list of registries, match the response against the
 registries we are paying attention to, and return the matching hash.
@@ -19,12 +19,8 @@ If registry is not avilable in server, then return `nothing`.
 
 Set `timeout=0` millseconds to disable timeout.
 """
-function query_latest_hash(registry::RegistryMeta, server::AbstractString; timeout::Integer=15_000)
+function query_latest_hash(registry::RegistryMeta, server::AbstractString; timeout::Integer=30_000)
     resource = "/registries"
-    if !url_exists(server * resource)
-        @warn "resource doesn't exists" resource=server*resource
-        return nothing
-    end
 
     f() = HTTP.get(server * resource)
     try
@@ -108,13 +104,13 @@ end
 
 
 """
-    url_exists(url; timeout=120_000)
+    url_exists(url; timeout=30_000)
 
 Send a `HEAD` request to the specified URL, returns `true` if the response is HTTP 200.
 
 Set `timeout=0` millseconds to disable timeout.
 """
-function url_exists(url::AbstractString; timeout::Integer=120_000, throw_warnings=true)
+function url_exists(url::AbstractString; timeout::Integer=30_000, throw_warnings=true)
     startswith(url, r"https?://") || throw(ArgumentError("invalid url $url, should be HTTP(S) protocol."))
 
     f() = HTTP.request("HEAD", url, status_exception=false)

--- a/test/tst_mirror_tarball.jl
+++ b/test/tst_mirror_tarball.jl
@@ -26,7 +26,7 @@ using StorageMirrorServer: timeout_call
         end
     end
 
-    rst_hash = timeout_call(1200) do
+    @time rst_hash = timeout_call(1200) do
         mirror_tarball(registry, server, tmp_testdir; packages=packages)
     end
     @test rst_hash == registry_hash

--- a/test/tst_mirror_tarball.jl
+++ b/test/tst_mirror_tarball.jl
@@ -4,9 +4,11 @@ using StorageMirrorServer: timeout_call
 
 @testset "mirror_tarball" begin
     tmp_testdir = mktempdir()
+    # tmp_testdir = "../julia"
+    # rm(tmp_testdir; force=true, recursive=true)
 
     registry = RegistryMeta("General", "23338594-aafe-5451-b93e-139f81909106", "https://github.com/JuliaRegistries/General")
-    server = "https://us-east.storage.juliahub.com"
+    server = ["https://us-east.storage.juliahub.com", "https://kr.storage.juliahub.com"]
     registry_hash = query_latest_hash(registry, server)
 
     tarball = joinpath(tmp_testdir, "registry", registry.uuid, registry_hash)
@@ -25,7 +27,7 @@ using StorageMirrorServer: timeout_call
     end
 
     rst_hash = timeout_call(1200) do
-        mirror_tarball(registry, [server], tmp_testdir; packages=packages)
+        mirror_tarball(registry, server, tmp_testdir; packages=packages)
     end
     @test rst_hash == registry_hash
 

--- a/test/tst_server_utils.jl
+++ b/test/tst_server_utils.jl
@@ -97,13 +97,8 @@ end
     ]
     for resource in resource_list
         tarball = joinpath(tmp_testdir, resource[2:end])
-        @test download_and_verify(server, resource, tarball)
+        @test download_and_verify(upstreams, resource, tarball)
         @test isfile(tarball)
-
-        rm(tarball; force=true)
-        @test download_and_verify([server], resource, tarball)
-        @test isfile(tarball)
-        rm(tarball; force=true)
     end
 
     # invalid hash


### PR DESCRIPTION
storage upstreams seem not responding very reliably, this commit introduces an asynchronous way to download from the first server that returns HEAD requests.